### PR TITLE
Support routing update and delete in Rally lib

### DIFF
--- a/rally_openstack/common/services/network/neutron.py
+++ b/rally_openstack/common/services/network/neutron.py
@@ -789,7 +789,7 @@ class NeutronService(service.Service):
             print("Routing rule not correct")
         return self.client.add_extra_routes_to_router(router_id, body)["router"]
 
-    @atomic.action_timer("neutron.add_extra_routes_to_router")
+    @atomic.action_timer("neutron.remove_extra_routes_from_router")
     def remove_extra_routes_from_router(self, router_id, destination=_NONE, nexthop=_NONE):
         body = {
                 "newRoutesWebRequest": {

--- a/rally_openstack/common/services/network/neutron.py
+++ b/rally_openstack/common/services/network/neutron.py
@@ -13,6 +13,7 @@
 #    under the License.
 
 import itertools
+import ipaddress
 
 from rally.common import cfg
 from rally.common import logging
@@ -781,8 +782,11 @@ class NeutronService(service.Service):
                         ]
                 }
             }
-        if not body:
-            raise TypeError("No updates for routes.")
+        try:
+            d = ipaddress.ip_network(destination)
+            n = ipaddress.ip_address(nexthop)
+        except:
+            print("Routing rule not correct")
         return self.client.add_extra_routes_to_router(router_id, body)["router"]
 
     @atomic.action_timer("neutron.add_extra_routes_to_router")
@@ -797,8 +801,11 @@ class NeutronService(service.Service):
                         ]
                 }
             }
-        if not body:
-            raise TypeError("No updates for routes.")
+        try:
+            d = ipaddress.ip_network(destination)
+            n = ipaddress.ip_address(nexthop)
+        except:
+            print("Routing rule not correct")
         return self.client.remove_extra_routes_from_router(router_id, body)["router"]
 
     @atomic.action_timer("neutron.delete_router")

--- a/rally_openstack/common/services/network/neutron.py
+++ b/rally_openstack/common/services/network/neutron.py
@@ -769,6 +769,38 @@ class NeutronService(service.Service):
 
         return self.client.update_router(router_id, {"router": body})["router"]
 
+    @atomic.action_timer("neutron.add_extra_routes_to_router")
+    def add_extra_routes_to_router(self, router_id, destination=_NONE, nexthop=_NONE):
+        body = {
+                "newRoutesWebRequest": {
+                    "routes": [
+                            {
+                                "destination": destination,
+                                "nexthop": nexthop
+                            }
+                        ]
+                }
+            }
+        if not body:
+            raise TypeError("No updates for routes.")
+        return self.client.add_extra_routes_to_router(router_id, body)["router"]
+
+    @atomic.action_timer("neutron.add_extra_routes_to_router")
+    def remove_extra_routes_from_router(self, router_id, destination=_NONE, nexthop=_NONE):
+        body = {
+                "newRoutesWebRequest": {
+                    "routes": [
+                            {
+                                "destination": destination,
+                                "nexthop": nexthop
+                            }
+                        ]
+                }
+            }
+        if not body:
+            raise TypeError("No updates for routes.")
+        return self.client.remove_extra_routes_from_router(router_id, body)["router"]
+
     @atomic.action_timer("neutron.delete_router")
     def delete_router(self, router_id):
         """Delete router

--- a/rally_openstack/task/scenarios/neutron/utils.py
+++ b/rally_openstack/task/scenarios/neutron/utils.py
@@ -183,6 +183,12 @@ class NeutronScenario(NeutronBaseScenario):
         """
         return {"subnet": self.neutron.get_subnet(subnet["subnet"]["id"])}
 
+    def _update_subnet_routetable(self, subnet_id, routetable_args):
+        return self.neutron.update_subnet_routetable(subnet_id, **routetable_args)
+
+    def _delete_subnet_routetable(self, subnet_id):
+        return self.neutron.delete_subnet_routetable(subnet_id)
+
     def _update_subnet(self, subnet, subnet_update_args):
         """Update the neutron subnet.
 

--- a/rally_openstack/task/scenarios/neutron/utils.py
+++ b/rally_openstack/task/scenarios/neutron/utils.py
@@ -252,6 +252,14 @@ class NeutronScenario(NeutronBaseScenario):
         return {"router": self.neutron.update_router(
             router["router"]["id"], **router_update_args)}
 
+    def _add_extra_routes(self, router, routes_args):
+        return {"router": self.neutron.add_extra_routes_to_router(
+            router["router"]["id"], **routes_args)}
+
+    def _remove_extra_routes(self, router, routes_args):
+        return {"router": self.neutron.remove_extra_routes_from_router(
+            router["router"]["id"], **routes_args)}
+
     def _create_port(self, network, port_create_args):
         """Create neutron port.
 


### PR DESCRIPTION
Rally lib does not support router level and subnet level routing rule update and delete test.

Add these function to support routing update and delete for rally test:

Router level:
1 add extra routes.
2 remove extra routes.

Subnet level:
1 update subnet routetable.
2 delete subnet routetable.

